### PR TITLE
Add next_upstream timeout and tries options

### DIFF
--- a/ngx_http_tnt_module.c
+++ b/ngx_http_tnt_module.c
@@ -199,6 +199,20 @@ static ngx_command_t  ngx_http_tnt_commands[] = {
       offsetof(ngx_http_tnt_loc_conf_t, upstream.next_upstream),
       &ngx_http_tnt_next_upstream_masks },
 
+    { ngx_string("tnt_next_upstream_timeout"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_msec_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_tnt_loc_conf_t, upstream.next_upstream_timeout),
+      NULL },
+
+    { ngx_string("tnt_next_upstream_tries"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_num_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_tnt_loc_conf_t, upstream.next_upstream_tries),
+      NULL },
+
     { ngx_string("tnt_in_multiplier"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_size_slot,
@@ -639,6 +653,9 @@ ngx_http_tnt_create_loc_conf(ngx_conf_t *cf)
     conf->upstream.connect_timeout =
     conf->upstream.send_timeout =
     conf->upstream.read_timeout = NGX_CONF_UNSET_MSEC;
+
+    conf->upstream.next_upstream_timeout = NGX_CONF_UNSET_MSEC;
+    conf->upstream.next_upstream_tries = NGX_CONF_UNSET;
 
     conf->upstream.buffer_size =
     conf->in_multiplier =


### PR DESCRIPTION
This PR adds support for two useful options: tnt_next_upstream_timeout and tnt_next_upstream_tries.