### PR TITLE
Fix compilation error

### DIFF
--- a/src/tp_transcode.c
+++ b/src/tp_transcode.c
@@ -761,8 +761,9 @@ yajl_json2tp_complete(void *ctx, size_t *complete_msg_size)
         return TP_TRANSCODE_OK;
     }
 
-    if (s_ctx->tc->errmsg == NULL)
+    if (s_ctx->tc->errmsg == NULL) {
         say_invalid_json(s_ctx);
+    }
 
     return TP_TRANSCODE_ERROR;
 }


### PR DESCRIPTION
Fix empty body compilation error:
```
...
cc -c -I/usr/include/luajit-2.0  -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -I/tmp/nginx_upstream_module/third_party -DNDK_SET_VAR         -I/tmp/nginx_upstream_module/src         -I/tmp/nginx_upstream_module/third_party         -I/tmp/nginx_upstream_module/third_party/msgpuck         -I/tmp/nginx_upstream_module/third_party/yajl/build/yajl-2.1.0/include           -I src/core -I src/event -I src/event/modules -I src/os/unix -I /tmp/ngx_devel_kit-0.2.19/objs -I objs/addon/ndk -I /tmp/lua-nginx-module-0.10.2/src/api -I objs -I src/http -I src/http/modules -I /tmp/ngx_devel_kit-0.2.19/src -I /usr/include/luajit-2.0 \
        -o objs/addon/src/tp_transcode.o \
        /tmp/nginx_upstream_module/src/tp_transcode.c
/tmp/nginx_upstream_module/src/tp_transcode.c: In function 'yajl_json2tp_complete':
/tmp/nginx_upstream_module/src/tp_transcode.c:82:52: error: suggest braces around empty body in an 'if' statement [-Werror=empty-body]
     dd("line:%d, code:%d,  msg:%s", __LINE__, c, e); \
                                                    ^
/tmp/nginx_upstream_module/src/tp_transcode.c:103:13: note: in expansion of macro 'say_error'
             say_error((ctx), -32700, "invalid json")
             ^
/tmp/nginx_upstream_module/src/tp_transcode.c:765:9: note: in expansion of macro 'say_invalid_json'
         say_invalid_json(s_ctx);
         ^
...
```