### PR TITLE
Fix dynamic module build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ all: build
 yajl:
 	echo "$(CUR_PATH)" > /dev/null
 	ln -sf src third_party/yajl/yajl
-	cd $(YAJL_PATH); ./configure; make distro
+	cd $(YAJL_PATH); CFLAGS=" -fPIC" ./configure; make distro
 
 gen_version:
 	$(shell cat $(MODULE_PATH)/src/ngx_http_tnt_version.h.in | sed 's/@VERSION_STRING@/"$(shell git describe --tags --dirty)"/g' > $(MODULE_PATH)/src/ngx_http_tnt_version.h)

--- a/config
+++ b/config
@@ -12,10 +12,10 @@ __include_paths=" \
           "
 
 __sources=" \
-          $__module_src_dir/src/ngx_http_tnt_module.c   \
-          $__module_src_dir/src/tp_transcode.c          \
-          $__module_src_dir/src/ngx_http_tnt_handlers.c \
-          $__module_src_dir/src/tp_allowed_methods.c    \
+          $__module_src_dir/ngx_http_tnt_module.c   \
+          $__module_src_dir/tp_transcode.c          \
+          $__module_src_dir/ngx_http_tnt_handlers.c \
+          $__module_src_dir/tp_allowed_methods.c    \
           "
 __headers=" \
           $__module_src_dir/debug.h                 \
@@ -67,7 +67,7 @@ else
   ngx_module_name=$ngx_addon_name
   ngx_module_incs=$__include_paths
   ngx_module_deps=$__headers
-  ngx_module_srcs=$__module_src_dir
+  ngx_module_srcs=$__sources
   ngx_module_libs=$__lib_yajl
 
   . auto/module


### PR DESCRIPTION
Tried to build the dynamic module version (`make build-all-dynamic`) and got the following error:

```sh
cc: error: addon/tarantool-nginx-module/src: No such file or directory
make: *** [objs/ngx_http_tnt_module.so] Error 1
[root@localhost nginx]# cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g  -I src/core -I src/event -I src/event/modules -I src/os/unix -I /tmp/tarantool-nginx-module/src -I /tmp/tarantool-nginx-module/third_party -I /tmp/tarantool-nginx-module/third_party/msgpuck -I /tmp/tarantool-nginx-module/third_party/yajl/build/yajl-2.1.0/include -I objs -I src/http -I src/http/modules \
> -o addon/tarantool-nginx-module/src \
> /tmp/tarantool-nginx-module/src
cc: warning: /tmp/tarantool-nginx-module/src: linker input file unused because linking not done
```

Looks like there was an extra layer of "src/" in module path. Plus, when I went further, I also stumbled upon the linking problem because libyajl has been built without "-fPIC".