### PR TITLE
Better error reporting in the config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,14 +379,14 @@ Example
            ngx.say(cjson.encode(result))
          else
            ngx.status = 502
-           ngx.say(res.body)
+           ngx.say("Tarantool does not work")
          end
 
          -- Finalize execution
          ngx.exit(ngx.OK)
        else
-         ngx.status = 502
-         ngx.say("Tarantool does not work")
+         ngx.status = res.status
+         ngx.say(res.body)
        end
        ';
     }


### PR DESCRIPTION
At least it reported JSON parsing error and stopped Tarantool cases as
it is supposed to do.